### PR TITLE
added 5 minute timeout to deleteJobs dynamically created steps

### DIFF
--- a/dsl/procedures/jobsCleanup/steps/deleteJobs.pl
+++ b/dsl/procedures/jobsCleanup/steps/deleteJobs.pl
@@ -178,6 +178,8 @@ do {
           $ec->createJobStep({
               subprocedure=>"subJC_deleteWorkspace",
               jobStepName => "Delete $jobStepWks-$jobStepHost-$totalNbSteps",
+              timeLimit => "5",
+              timeLimitUnits => "minutes",
               actualParameter => [
                 {actualParameterName => "computeUsage",    value => $computeUsage},
                 {actualParameterName => "executeDeletion", value => $executeDeletion},


### PR DESCRIPTION
I ran this and it appears to have successfully accomplished what I hoped it would.  At any rate the job completed after 2 hours and deleting nearly 9000 workspaces....
I only changed the step content.  I did not do anything to procedure a new jar.  Not sure what the current process is for that.